### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
     {[testenv:build]commands}
     {[testenv:pep8]commands}
 
-[testenv:linters-2.9]
+[testenv:linters-29]
 passenv = {[testenv:linters]passenv}
 commands = {[testenv:linters]commands}
 deps =


### PR DESCRIPTION
Fix `tox.ini` to be used with `tox-linters-ansible-2.9`

Depends-On: https://github.com/opentelekomcloud-infra/otc-zuul-jobs/pull/37